### PR TITLE
Workaround(?) for joint state error + Pose Target fix(?)

### DIFF
--- a/lab09_gazebo/config/ur5e_controllers.yaml
+++ b/lab09_gazebo/config/ur5e_controllers.yaml
@@ -1,6 +1,8 @@
 joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: &loop_hz 500
+  extra_joints:
+    - name: 'epick_end_effector_joint'
 
 pos_joint_traj_controller:
   type: position_controllers/JointTrajectoryController


### PR DESCRIPTION
### Joint State Error
Added lines to tell Gazebo to publish values for the end effector joint, as mentioned in [the docs](http://docs.ros.org/en/jade/api/joint_state_controller/html/c++/classjoint__state__controller_1_1JointStateController.html). The position/velocity/effort of the joint will always be 0. This doesn't seem to have any impact on the behaviour of the code. 

I'm not convinced that this is the 'correct' way to solve this, but this was the only way I could find to get rid of this error from my experimentation.

### Cartesian / Pose Planner Potential fix
I *think* that the inability to use the `setPoseTarget` function and similar is due to a limitation of the UR5KinematicsPlugin Kinematic Solver used in the MoveIt configuration of the manipulator planning group.

In lab05, the configuration seems to use KDLKinematicsPlugin. Changing the lab09 configuration to use this instead seems to work, but I haven't tested it very much.

I haven't pushed this change to the config - I'm not sure if changing the Kinematic Solver would have any other consequences to the behaviour.