### PR TITLE
Added custom vacuum gripper which can handle rotations

### DIFF
--- a/better_epick/CMakeLists.txt
+++ b/better_epick/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.5.1)
+
+project(better_epick)
+
+find_package(catkin REQUIRED COMPONENTS
+  gazebo_dev
+  message_generation
+  gazebo_msgs
+  roscpp
+  rospy
+  std_srvs
+  geometry_msgs
+  urdf
+  tf
+  tf2_ros
+  std_msgs
+  visualization_msgs
+)
+
+include_directories(include
+  ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+)
+
+link_directories(
+  ${catkin_LIBRARY_DIRS}
+  ${GAZEBO_LIBRARY_DIRS}
+)
+
+
+add_library(better_epick SHARED src/better_epick.cpp)
+target_link_libraries(better_epick ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES} )

--- a/better_epick/package.xml
+++ b/better_epick/package.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>better_epick</name>
+  <version>0.0.0</version>
+  <description>The better_epick package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="mtrn4230@todo.todo">mtrn4230</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/pattern_creation</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <depend>gazebo_ros</depend>
+  <depend>urdf</depend>
+  <depend>tf</depend>
+  <depend>tf2_ros</depend>
+  <depend>gazebo_msgs</depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" />
+  </export>
+</package>

--- a/better_epick/src/better_epick.cpp
+++ b/better_epick/src/better_epick.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2015 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+/*
+   Desc: GazeboVacuumGripper plugin for manipulating objects in Gazebo
+   Author: Kentaro Wada
+   Date: 7 Dec 2015
+   Modified by: Terry Lim
+   Date: 15 August 2021
+ */
+
+#include <algorithm>
+#include <assert.h>
+
+#include <std_msgs/Bool.h>
+#include "better_epick.h"
+
+
+namespace gazebo
+{
+GZ_REGISTER_MODEL_PLUGIN(BetterEPick);
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+BetterEPick::BetterEPick()
+{
+  connect_count_ = 0;
+  status_ = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+BetterEPick::~BetterEPick()
+{
+  //event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  update_connection_.reset();
+
+  // Custom Callback Queue
+  queue_.clear();
+  queue_.disable();
+  rosnode_->shutdown();
+  callback_queue_thread_.join();
+
+  delete rosnode_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void BetterEPick::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  ROS_INFO("Loading gazebo_ros_vacuum_gripper");
+
+  // Set attached model;
+  parent_ = _model;
+
+  // Get the world name.
+  world_ = _model->GetWorld();
+
+  // load parameters
+  robot_namespace_ = "";
+  if (_sdf->HasElement("robotNamespace"))
+    robot_namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>() + "/";
+
+  if (!_sdf->HasElement("bodyName"))
+  {
+    ROS_FATAL("vacuum_gripper plugin missing <bodyName>, cannot proceed");
+    return;
+  }
+  else
+    link_name_ = _sdf->GetElement("bodyName")->Get<std::string>();
+
+  link_ = _model->GetLink(link_name_);
+  if (!link_)
+  {
+    std::string found;
+    physics::Link_V links = _model->GetLinks();
+    for (size_t i = 0; i < links.size(); i++) {
+      found += std::string(" ") + links[i]->GetName();
+    }
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: link named: %s does not exist", link_name_.c_str());
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: You should check it exists and is not connected with fixed joint");
+    ROS_FATAL("gazebo_ros_vacuum_gripper plugin error: Found links are: %s", found.c_str());
+    return;
+  }
+
+  if (!_sdf->HasElement("topicName"))
+  {
+    ROS_FATAL("vacuum_gripper plugin missing <serviceName>, cannot proceed");
+    return;
+  }
+  else
+    topic_name_ = _sdf->GetElement("topicName")->Get<std::string>();
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  // Parameters for Vacuum Mechanism
+  // max force: [N]
+  if (_sdf->HasElement("maxForce")) {
+    max_force_ = _sdf->GetElement("maxForce")->Get<double>();
+  } else {
+    max_force_ = 20;
+  }
+  // max distance to apply force: [m]
+  if (_sdf->HasElement("maxDistance")) {
+    max_distance_ = _sdf->GetElement("maxDistance")->Get<double>();
+  } else {
+    max_distance_ = 0.05;
+  }
+  // distance to apply friction: [m]
+  if (_sdf->HasElement("minDistance")) {
+    min_distance_ = _sdf->GetElement("minDistance")->Get<double>();
+  } else {
+    min_distance_ = 0.01;
+  }
+
+  rosnode_ = new ros::NodeHandle(robot_namespace_);
+
+  // Custom Callback Queue
+  ros::AdvertiseOptions ao = ros::AdvertiseOptions::create<std_msgs::Bool>(
+    topic_name_, 1,
+    boost::bind(&BetterEPick::Connect, this),
+    boost::bind(&BetterEPick::Disconnect, this),
+    ros::VoidPtr(), &queue_);
+  pub_ = rosnode_->advertise(ao);
+
+  // Custom Callback Queue
+  ros::AdvertiseServiceOptions aso1 =
+    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+    "on", boost::bind(&BetterEPick::OnServiceCallback,
+    this, _1, _2), ros::VoidPtr(), &queue_);
+  srv1_ = rosnode_->advertiseService(aso1);
+  ros::AdvertiseServiceOptions aso2 =
+    ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+    "off", boost::bind(&BetterEPick::OffServiceCallback,
+    this, _1, _2), ros::VoidPtr(), &queue_);
+  srv2_ = rosnode_->advertiseService(aso2);
+
+  // Custom Callback Queue
+  callback_queue_thread_ = boost::thread( boost::bind( &BetterEPick::QueueThread,this ) );
+
+  // New Mechanism for Updating every World Cycle
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  update_connection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&BetterEPick::UpdateChild, this));
+
+  ROS_INFO("Loaded gazebo_ros_vacuum_gripper");
+}
+
+bool BetterEPick::OnServiceCallback(std_srvs::Empty::Request &req,
+                                     std_srvs::Empty::Response &res)
+{
+  if (status_) {
+    ROS_WARN("gazebo_ros_vacuum_gripper: already status is 'on'");
+  } else {
+    status_ = true;
+    ROS_INFO("gazebo_ros_vacuum_gripper: status: off -> on");
+  }
+  return true;
+}
+bool BetterEPick::OffServiceCallback(std_srvs::Empty::Request &req,
+                                     std_srvs::Empty::Response &res)
+{
+  if (status_) {
+    status_ = false;
+    ROS_INFO("gazebo_ros_vacuum_gripper: status: on -> off");
+  } else {
+    ROS_WARN("gazebo_ros_vacuum_gripper: already status is 'off'");
+  }
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void BetterEPick::UpdateChild()
+{
+  std_msgs::Bool grasping_msg;
+  grasping_msg.data = false;
+  if (!status_) {
+    pub_.publish(grasping_msg);
+    count = 0;
+    return;
+  }
+  // apply force
+  lock_.lock();
+  ignition::math::Pose3d parent_pose = link_->WorldPose();
+  physics::Model_V models = world_->Models();
+  for (size_t i = 0; i < models.size(); i++) {
+    if (models[i]->GetName() == link_->GetName() ||
+        models[i]->GetName() == parent_->GetName())
+    {
+      continue;
+    }
+    physics::Link_V links = models[i]->GetLinks();
+    for (size_t j = 0; j < links.size(); j++) {
+      ignition::math::Pose3d link_pose = links[j]->WorldPose();
+      ignition::math::Pose3d diff = parent_pose - link_pose;
+      double norm = diff.Pos().Length();
+      if (norm <= max_distance_) {
+        // Record initial reference
+        if (count++ < 1) {
+          initial_parent_rot = parent_pose.Rot();
+          initial_link_rot = link_pose.Rot();
+        }
+        links[j]->SetLinearAccel(link_->WorldLinearAccel());
+        links[j]->SetAngularAccel(ignition::math::Vector3d(0, 0, 0));
+        links[j]->SetLinearVel(link_->WorldLinearVel());
+        links[j]->SetAngularVel(ignition::math::Vector3d(0, 0, 0));
+        // Update rotation of picked object as the gripper rotates.
+        link_pose.Set(parent_pose.Pos(), parent_pose.Rot()*initial_parent_rot.Inverse()*initial_link_rot);
+        links[j]->SetWorldPose(link_pose);
+        grasping_msg.data = true;
+        // Only pick up one item at a time.
+        break;
+      }
+    }
+  }
+  pub_.publish(grasping_msg);
+  lock_.unlock();
+}
+
+// Custom Callback Queue
+////////////////////////////////////////////////////////////////////////////////
+// custom callback queue thread
+void BetterEPick::QueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (rosnode_->ok())
+  {
+    queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void BetterEPick::Connect()
+{
+  this->connect_count_++;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Someone subscribes to me
+void BetterEPick::Disconnect()
+{
+  this->connect_count_--;
+}
+
+}  // namespace gazebo

--- a/better_epick/src/better_epick.h
+++ b/better_epick/src/better_epick.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2015-2016 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+   Desc: GazeboVacuumGripper plugin for manipulating objects in Gazebo
+ * Author: Kentaro Wada
+ * Date: 7 Dec 2015
+ * Modified by: Terry Lim
+ * Date: 15 August 2021
+ */
+
+#ifndef GAZEBO_ROS_VACUUM_GRIPPER_HH
+#define GAZEBO_ROS_VACUUM_GRIPPER_HH
+
+#include <string>
+
+// Custom Callback Queue
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+#include <ros/advertise_service_options.h>
+#include <std_srvs/Empty.h>
+
+#include <ros/ros.h>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+#include <ignition/math/Pose3.hh>
+
+namespace gazebo
+{
+/// @addtogroup gazebo_dynamic_plugins Gazebo ROS Dynamic Plugins
+/// @{
+/** \defgroup BetterEPick Plugin XML Reference and Example
+  \brief Ros Vacuum Gripper Plugin.
+  This is a Plugin that collects data from a ROS topic and applies wrench to a body accordingly.
+  Example Usage:
+    - left_end_effector will be the power point
+    - revolute type joint is necessary (fixed joint disappears on gazebo and plugin can't find the joint and link)
+  \verbatim
+    <link name="left_end_effector">
+      <gravity>0</gravity>
+      <visual>
+        <origin rpy="0 0 0" xyz="0 0 0"/>
+        <geometry>
+          <box size="0.01 0.01 0.01"/>
+        </geometry>
+        <material name="transparent">
+          <color rgba="0 0 0 0"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin rpy="0 0 0" xyz="0.000000 0.000000 0.000000"/>
+        <mass value="0.0001"/>
+        <inertia ixx="1e-08" ixy="0" ixz="0" iyy="1e-08" iyz="0" izz="1e-08"/>
+      </inertial>
+    </link>
+    <joint name="left_end_joint" type="revolute">
+      <parent link="left_wrist" />
+      <child link="left_end_effector" />
+      <origin rpy="0 0 0" xyz="0.08 0 .44" />
+      <limit effort="30" velocity="1.0" lower="0" upper="0" />
+    </joint>
+    <gazebo>
+      <plugin name="gazebo_ros_vacuum_gripper" filename="libgazebo_ros_vacuum_gripper.so">
+        <robotNamespace>/robot/left_vacuum_gripper</robotNamespace>
+        <bodyName>left_end_effector</bodyName>
+        <topicName>grasping</topicName>
+      </plugin>
+    </gazebo>
+  \endverbatim
+\{
+*/
+
+
+class BetterEPick : public ModelPlugin
+{
+  /// \brief Constructor
+  public: BetterEPick();
+
+  /// \brief Destructor
+  public: virtual ~BetterEPick();
+
+  // Documentation inherited
+  protected: void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+
+  // Documentation inherited
+  protected: virtual void UpdateChild();
+
+  /// \brief The custom callback queue thread function.
+  private: void QueueThread();
+
+  private: bool OnServiceCallback(std_srvs::Empty::Request &req,
+                                std_srvs::Empty::Response &res);
+  private: bool OffServiceCallback(std_srvs::Empty::Request &req,
+                                std_srvs::Empty::Response &res);
+
+  private: bool status_;
+
+  private: physics::ModelPtr parent_;
+
+  /// \brief A pointer to the gazebo world.
+  private: physics::WorldPtr world_;
+
+  /// \brief A pointer to the Link, where force is applied
+  private: physics::LinkPtr link_;
+
+  /// \brief A pointer to the ROS node.  A node will be instantiated if it does not exist.
+  private: ros::NodeHandle* rosnode_;
+
+  /// \brief A mutex to lock access to fields that are used in ROS message callbacks
+  private: boost::mutex lock_;
+  private: ros::Publisher pub_;
+  private: ros::ServiceServer srv1_;
+  private: ros::ServiceServer srv2_;
+
+  /// \brief ROS Wrench topic name inputs
+  private: std::string topic_name_;
+  private: std::string service_name_;
+  /// \brief The Link this plugin is attached to, and will exert forces on.
+  private: std::string link_name_;
+
+  /// \brief for setting ROS name space
+  private: std::string robot_namespace_;
+
+  /// \brief vacuum mechanism parameters
+  private: double max_force_;
+  private: double max_distance_;
+  private: double min_distance_;
+
+  // Custom Callback Queue
+  private: ros::CallbackQueue queue_;
+  /// \brief Thead object for the running callback Thread.
+  private: boost::thread callback_queue_thread_;
+
+  // Pointer to the update event connection
+  private: event::ConnectionPtr update_connection_;
+
+  /// \brief: keep track of number of connections
+  private: int connect_count_;
+  private: void Connect();
+  private: void Disconnect();
+  private: int count = 0;
+  private: ignition::math::Quaterniond initial_parent_rot;
+  private: ignition::math::Quaterniond initial_link_rot;
+};
+/** \} */
+/// @}
+}
+#endif

--- a/lab09_gazebo/urdf/inc/robotiq_epick.gazebo.xacro
+++ b/lab09_gazebo/urdf/inc/robotiq_epick.gazebo.xacro
@@ -4,7 +4,7 @@
   <xacro:macro name="epick_hand_gazebo" params="robot_name">
     <!-- http://docs.ros.org/melodic/api/gazebo_plugins/html/group__GazeboRosVacuumGripper.html -->
     <gazebo>
-      <plugin name="gazebo_ros_vacuum_gripper" filename="libgazebo_ros_vacuum_gripper.so">
+      <plugin name="better_epick" filename="libbetter_epick.so">
         <robotNamespace>${robot_name}/epick</robotNamespace>
         <bodyName>epick_end_effector</bodyName>
         <topicName>grasping</topicName>


### PR DESCRIPTION
Here's my version of the Epick gripper plugin.
It has been modified to be simple and still work. Main changes are:
- When turned on, the plugin will search for the first object within max_distance_ of the gripper and focus only on that single object.
- There is no force being applied to it. It will simply set the pose to stick to the gripper and keep it updated while the gripper is on.

Note that I have the rotations update with respect to initial rotations (at the time of the gripper first connecting to the object). This is effectively emulates perfect friction / no sliding and prevents the attached object from rotating with respect to the gripper.

And also.. I have not actually tested on this repo as lab09's current stuff doesn't run on my setup (fails to spawn cube with input xml format not recognised). So someone else will need to test it, thanks.
It should work just fine though.